### PR TITLE
Fix qr-code: SVG scales to `size` (viewBox case-sensitivity)

### DIFF
--- a/stubs/ui/qr-code.blade.php
+++ b/stubs/ui/qr-code.blade.php
@@ -486,7 +486,10 @@
         xmlns="http://www.w3.org/2000/svg"
         role="img"
         aria-label="{{ $label }}"
-        :viewBox="viewBox"
+        {{-- SVG's viewBox is case-sensitive; Alpine's `:viewBox` bind is lowercased to
+             `viewbox` by the HTML parser and silently ignored. Set it from JS (setAttribute
+             preserves case) so the code scales to `size` instead of rendering at 1px/module. --}}
+        x-effect="$el.setAttribute('viewBox', viewBox)"
         width="{{ (int) $size }}"
         height="{{ (int) $size }}"
         class="block h-full w-full"

--- a/tests/BlatuiTest.php
+++ b/tests/BlatuiTest.php
@@ -74,6 +74,18 @@ class BlatuiTest extends TestCase
         );
     }
 
+    public function test_qr_code_sets_viewbox_with_correct_case(): void
+    {
+        // SVG's `viewBox` is case-sensitive. An Alpine `:viewBox` bind is lowercased to
+        // `viewbox` by the HTML parser and silently ignored, so the code never scales to
+        // `size` (it renders at 1px per module). Guard against that regression: the stub
+        // must set the attribute imperatively (setAttribute preserves case), not via bind.
+        $stub = file_get_contents(dirname(__DIR__).'/stubs/ui/qr-code.blade.php');
+
+        $this->assertStringContainsString("setAttribute('viewBox'", $stub);
+        $this->assertStringNotContainsString(':viewBox=', $stub);
+    }
+
     public function test_doctor_flags_typeless_button_in_form(): void
     {
         $dir = sys_get_temp_dir().'/blatui-doctor-'.uniqid();


### PR DESCRIPTION
## Problem

The `qr-code` component renders a tiny code (~1px per module) floating in the middle of the configured `size` box, instead of scaling to fill it.

**Root cause:** the SVG binds `:viewBox="viewBox"`. Alpine's bound attribute name is lowercased to `viewbox` by the HTML parser, but SVG's `viewBox` attribute is **case-sensitive** — the browser silently ignores `viewbox`. With no valid viewBox, `svg.viewBox.baseVal` is `{0,0,0,0}` and 1 module maps to 1px, so a version-3 code (37 modules) renders at ~37px regardless of `size` (160, 220, …).

Verified in a real browser: `hasAttribute('viewBox')` → false, only a lowercase `viewbox` attribute is present.

## Fix

Set the attribute imperatively via `x-effect` — `setAttribute` preserves case (only the HTML *parser* lowercases), and it stays reactive if `viewBox` recomputes:

```diff
-        :viewBox="viewBox"
+        x-effect="$el.setAttribute('viewBox', viewBox)"
```

After the fix the QR fills its box, crisp and scannable, at every `size`.

## Test

Adds `test_qr_code_sets_viewbox_with_correct_case` — a regression guard that fails if the stub reverts to the case-sensitive `:viewBox` bind.

`vendor/bin/pint --test` ✓ · `vendor/bin/phpunit` ✓ (34 tests)